### PR TITLE
Update Venn and UpSet to Plotly version 2.0.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 3.0.1 - Monday, May 16, 2022
+
+* Update Venn and UpSet Plots to Plotly Version 2.0.0
+
 ### 3.0.0 - Wednesday, December 8, 2021
 
 * Separate package from BioFSharp

--- a/src/BioFSharp.Vis/BioFSharp.Vis.fsproj
+++ b/src/BioFSharp.Vis/BioFSharp.Vis.fsproj
@@ -47,6 +47,6 @@
     <PackageReference Update="FSharp.Core" Version="4.*" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Xaml" Version="4.0.0.1" />
-    <PackageReference Include="Plotly.NET" Version="2.0.0-preview.12" />
+    <PackageReference Include="Plotly.NET" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/src/BioFSharp.Vis/Upset.fs
+++ b/src/BioFSharp.Vis/Upset.fs
@@ -19,7 +19,7 @@ module UpSetParts =
         LinearAxis.init(Range=range, ShowGrid=false, ShowLine=false, ShowTickLabels=false, ZeroLine=false)
 
     /// Creates a linear axis without lines and ticks with a given range and domain
-    let createLinearAxisWithRangeDomain (maxRange: float) (domain: float*float) =
+    let createLinearAxisWithRangeDomain (maxRange: float) (domain) =
         let range  = StyleParam.Range.MinMax (-0.5,maxRange)
         LinearAxis.init(Range=range, ShowGrid=false, ShowLine=false, ShowTickLabels= false, ZeroLine=false, Domain=StyleParam.Range.MinMax domain)
 
@@ -33,9 +33,9 @@ module UpSetParts =
         Chart.Line (
             data,
             ShowMarkers = true,
-            Dash = StyleParam.DrawingStyle.Solid,
-            Width = (float markerSize / 5.),
-            Color = color
+            LineDash = StyleParam.DrawingStyle.Solid,
+            LineWidth = (float markerSize / 5.),
+            LineColor = color
         )
         |> Chart.withMarkerStyle(
             Symbol = StyleParam.MarkerSymbol.Circle,
@@ -88,20 +88,20 @@ module UpSetParts =
             labelCount
             |> Array.maxBy snd
             |> snd
-        Chart.Bar (labelCount, Color = color)
+        Chart.Bar (labelCount, MarkerColor = color)
         |> Chart.withXAxisStyle("Set Size",MinMax=(float maxSetSize,0.), Domain=domainSet, TitleFont=textFont)
         |> Chart.withYAxis (createLinearAxisWithRange maxY)
-        |> Chart.withTraceName(ShowLegend=false)
+        |> Chart.withTraceInfo(ShowLegend=false)
 
     /// Creates a bar chart with the intersection sizes
     let createIntersectionSizePlots (intersectionCount: (string list*int)[]) (maxX: float) (color: Color) (domainIntersection: float*float) (textFont: Font) =
         intersectionCount
         |> Array.map snd
         |> fun count -> 
-            Chart.Column(count, Color = color)
+            Chart.Column(count, MarkerColor = color)
         |> Chart.withXAxis (createLinearAxisWithRangeDomain maxX domainIntersection)
         |> Chart.withYAxisStyle("Intersection Size", TitleFont=textFont)
-        |> Chart.withTraceName(ShowLegend=false)
+        |> Chart.withTraceInfo(ShowLegend=false)
 
     /// Aligns the map with Setelement->Feature to the intersections
     let alignIntersectionData (venn: (string list * Set<'a>)[]) (setData: Map<'a,'b>) =
@@ -159,8 +159,8 @@ module UpSet =
             let setData             = setData             |> Option.defaultValue Array.empty
             let setDataChartsTitle  = setDataChartsTitle  |> Option.defaultValue Array.empty
             let markerSize          = markerSize          |> Option.defaultValue 25
-            let mainColor           = mainColor           |> Option.defaultValue Color.Table.Office.darkBlue
-            let secondaryColor      = secondaryColor      |> Option.defaultValue Color.Table.Office.lightBlue
+            let mainColor           = mainColor           |> Option.defaultValue (Color.fromKeyword DarkBlue)
+            let secondaryColor      = secondaryColor      |> Option.defaultValue (Color.fromKeyword LightBlue)
             let domainSet           = domainSet           |> Option.defaultValue (0., 0.2)
             let domainIntersection  = domainIntersection  |> Option.defaultValue (0.3, 1.)
             let textFont            = textFont            |> Option.defaultValue (Font.init(StyleParam.FontFamily.Arial, Size=20.))
@@ -204,7 +204,7 @@ module UpSet =
                 |> Chart.combine
                 |> Chart.withYAxis (createLinearAxisWithRangeTickLabel maxY labels textFontLabel)
                 |> Chart.withXAxis (createLinearAxisWithRangeDomain maxX domainIntersection)
-                |> Chart.withTraceName(ShowLegend=false)
+                |> Chart.withTraceInfo(ShowLegend=false)
             let setSizePlot = createSetSizePlot labels sets maxY mainColor domainSet textFont
             let intersectionSizePlot = createIntersectionSizePlots vennCount maxX mainColor domainIntersection textFont
             let grid =

--- a/src/BioFSharp.Vis/Venn.fs
+++ b/src/BioFSharp.Vis/Venn.fs
@@ -103,7 +103,7 @@ module Venn =
     
             match sets.Length with
             | 2 ->
-                let colors = colors |> Option.defaultValue ([|Color.Table.Office.blue; Color.Table.Office.red|])
+                let colors = colors |> Option.defaultValue ([|Color.fromKeyword Blue; Color.fromKeyword Red|])
                 let shapes =
                     Array.zip
                         [|
@@ -124,15 +124,15 @@ module Venn =
                                 Bottom = 100
                             )
                     )
-                    |> Layout.AddLinearAxis(StyleParam.SubPlotId.XAxis 1, axis)
-                    |> Layout.AddLinearAxis(StyleParam.SubPlotId.YAxis 1, axis)
-                let positionSet,textSet =
+                    |> Layout.updateLinearAxisById(StyleParam.SubPlotId.XAxis 1, axis)
+                    |> Layout.updateLinearAxisById(StyleParam.SubPlotId.YAxis 1, axis)
+                let textSet =
                     let vennSingleText =
                         vennCount
                         |> Array.filter (fun (label,_) -> label.Length = 1)
                         |> Array.map (fun (label,count) ->
                             sprintf "%s<br>%i" label.[0] count
-                        )       
+                        )
                     let intersectionText =
                         vennCount
                         |> Array.filter (fun (label,_) -> label.Length > 1)
@@ -140,17 +140,20 @@ module Venn =
                             sprintf "%i" count
                         )
                             
-                    [|1.,1.;2.5,1.;1.75,1.|],
                     Array.append vennSingleText intersectionText
-                Chart.Scatter(
-                    positionSet,
-                    StyleParam.Mode.Text,
-                    Labels = textSet,
-                    TextFont = textFont
+                Trace2D.initScatter(
+                    Trace2DStyle.Scatter(
+                        X = [|1.; 2.5; 1.75|],
+                        Y = [|1.; 1.; 1.|],
+                        Mode = StyleParam.Mode.Text,
+                        MultiText = textSet,
+                        TextFont = textFont
+                    )
                 )
+                |> GenericChart.ofTraceObject true
                 |> Chart.withLayout layout
             | 3 ->
-                let colors = colors |> Option.defaultValue ([|Color.Table.Office.blue; Color.Table.Office.red; Color.Table.Office.green|])
+                let colors = colors |> Option.defaultValue ([|Color.fromKeyword Blue; Color.fromKeyword Red; Color.fromKeyword Green|])
                 let shapes =
                     Array.zip
                         [|
@@ -166,9 +169,9 @@ module Venn =
                     Layout.init(
                         Shapes = shapes
                     )
-                    |> Layout.AddLinearAxis(StyleParam.SubPlotId.XAxis 1, axis)
-                    |> Layout.AddLinearAxis(StyleParam.SubPlotId.YAxis 1, axis)
-                let positionSet,textSet =
+                    |> Layout.updateLinearAxisById(StyleParam.SubPlotId.XAxis 1, axis)
+                    |> Layout.updateLinearAxisById(StyleParam.SubPlotId.YAxis 1, axis)
+                let textSet =
                     let vennSingleText =
                         vennCount
                         |> Array.filter (fun (label,_) -> label.Length = 1)
@@ -198,15 +201,17 @@ module Venn =
                         |> Array.map (fun (label,count) ->
                             sprintf "%i" count
                         )
-                            
-                    [|1.,1.;2.5,1.;1.75,2.25;1.75,1.; 1.325,1.6625;2.125,1.6625;1.75,1.45|],
                     Array.append vennSingleText intersectionText
-                Chart.Scatter(
-                    positionSet,
-                    StyleParam.Mode.Text,
-                    Labels = textSet,
-                    TextFont = textFont
+                Trace2D.initScatter(
+                    Trace2DStyle.Scatter(
+                        X = [|1.; 2.5; 1.75; 1.75; 1.325; 2.125; 1.75|],
+                        Y = [|1.; 1.; 2.25; 1.; 1.6625; 1.6625; 1.45|],
+                        Mode = StyleParam.Mode.Text,
+                        MultiText = textSet,
+                        TextFont = textFont
+                    )
                 )
+                |> GenericChart.ofTraceObject true
                 |> Chart.withLayout layout
             | _ -> failwith "Only 2 or 3 sets are supported"
 


### PR DESCRIPTION
Update the Venn and UpSet plots to use the version 2.0.0 of Plotly (latest stable major release)